### PR TITLE
fix type for lcz in schemas

### DIFF
--- a/src/lib/utils/schemas.ts
+++ b/src/lib/utils/schemas.ts
@@ -11,7 +11,7 @@ export const RawStationMetadataSchema = z.object({
 	longitude: z.number(),
 	altitude: z.number(),
 	district: z.string(),
-	lcz: z.number().nullable(),
+	lcz: z.string().nullable(),
 	measured_at: z.string().optional(),
 	station_type: StationTypeSchema
 });


### PR DESCRIPTION
Hey, I just filled a bit more of our station metadata (altitude, districts, and LCZs). After doing so, I got a 500 from vercel, so I wondered if it was my fault. Before LCZs were always NULL because they were not filled, now with them being filled, I got the 500.

I checked the schemas and found an incorrect numeric type:

LCZs are an enum/set of literal string see:

![image](https://github.com/user-attachments/assets/ea22196a-dfc2-4b95-8c32-4613cf233397)

(I set them to `NULL` in the db again, so it's working now. I will wait for this until I populate it again)